### PR TITLE
Formatting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,20 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: [
+    '@typescript-eslint',
+  ],
+  extends: [
+    'plugin:storybook/recommended',
+    'eslint:recommended',
+    'prettier'
+  ],
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      rules: {
+        'no-undef': 'off',
+      },
+    },
+  ],
+};

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,5 @@
   "semi": true,
   "jsxSingleQuote": true,
   "singleQuote": true,
-  "tabWidth": 4
+  "tabWidth": 2
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "@huddly/component-library",
             "version": "0.1.0",
             "dependencies": {
+                "pretty-quick": "^3.1.3",
                 "styled-components": "^5.3.3",
                 "web-vitals": "^2.1.4"
             },
@@ -28,6 +29,15 @@
                 "@types/react": "^17.0.38",
                 "@types/react-dom": "^17.0.11",
                 "@types/styled-components": "^5.1.21",
+                "@typescript-eslint/eslint-plugin": "^5.12.0",
+                "@typescript-eslint/parser": "^5.12.0",
+                "eslint": "^8.9.0",
+                "eslint-config-prettier": "^8.4.0",
+                "eslint-plugin-import": "^2.25.4",
+                "eslint-plugin-jsx-a11y": "^6.5.1",
+                "eslint-plugin-react": "^7.28.0",
+                "eslint-plugin-react-hooks": "^4.3.0",
+                "eslint-plugin-storybook": "^0.5.7",
                 "pre-commit": "^1.2.2",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
@@ -2342,14 +2352,14 @@
             "dev": true
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
-            "integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
+            "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.2.0",
+                "espree": "^9.3.1",
                 "globals": "^13.9.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.2.1",
@@ -2368,9 +2378,9 @@
             "dev": true
         },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
-            "version": "13.12.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-            "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+            "version": "13.12.1",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
+            "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -11678,8 +11688,7 @@
         "node_modules/@types/minimatch": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-            "dev": true
+            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
         },
         "node_modules/@types/minimist": {
             "version": "1.2.2",
@@ -11989,14 +11998,14 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.10.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz",
-            "integrity": "sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==",
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.12.0.tgz",
+            "integrity": "sha512-fwCMkDimwHVeIOKeBHiZhRUfJXU8n6xW1FL9diDxAyGAFvKcH4csy0v7twivOQdQdA0KC8TDr7GGRd3L4Lv0rQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.10.1",
-                "@typescript-eslint/type-utils": "5.10.1",
-                "@typescript-eslint/utils": "5.10.1",
+                "@typescript-eslint/scope-manager": "5.12.0",
+                "@typescript-eslint/type-utils": "5.12.0",
+                "@typescript-eslint/utils": "5.12.0",
                 "debug": "^4.3.2",
                 "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.1.8",
@@ -12021,6 +12030,126 @@
                 }
             }
         },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.0.tgz",
+            "integrity": "sha512-GAMobtIJI8FGf1sLlUWNUm2IOkIjvn7laFWyRx7CLrv6nLBI7su+B7lbStqVlK5NdLvHRFiJo2HhiDF7Ki01WQ==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.12.0",
+                "@typescript-eslint/visitor-keys": "5.12.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.0.tgz",
+            "integrity": "sha512-JowqbwPf93nvf8fZn5XrPGFBdIK8+yx5UEGs2QFAYFI8IWYfrzz+6zqlurGr2ctShMaJxqwsqmra3WXWjH1nRQ==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.0.tgz",
+            "integrity": "sha512-Dd9gVeOqt38QHR0BEA8oRaT65WYqPYbIc5tRFQPkfLquVEFPD1HAtbZT98TLBkEcCkvwDYOAvuSvAD9DnQhMfQ==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.12.0",
+                "@typescript-eslint/visitor-keys": "5.12.0",
+                "debug": "^4.3.2",
+                "globby": "^11.0.4",
+                "is-glob": "^4.0.3",
+                "semver": "^7.3.5",
+                "tsutils": "^3.21.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.12.0.tgz",
+            "integrity": "sha512-k4J2WovnMPGI4PzKgDtQdNrCnmBHpMUFy21qjX2CoPdoBcSBIMvVBr9P2YDP8jOqZOeK3ThOL6VO/sy6jtnvzw==",
+            "dev": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "@typescript-eslint/scope-manager": "5.12.0",
+                "@typescript-eslint/types": "5.12.0",
+                "@typescript-eslint/typescript-estree": "5.12.0",
+                "eslint-scope": "^5.1.1",
+                "eslint-utils": "^3.0.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.0.tgz",
+            "integrity": "sha512-cFwTlgnMV6TgezQynx2c/4/tx9Tufbuo9LPzmWqyRC3QC4qTGkAG1C6pBr0/4I10PAI/FlYunI3vJjIcu+ZHMg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.12.0",
+                "eslint-visitor-keys": "^3.0.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
         "node_modules/@typescript-eslint/experimental-utils": {
             "version": "5.10.1",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.10.1.tgz",
@@ -12041,14 +12170,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.10.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
-            "integrity": "sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==",
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.12.0.tgz",
+            "integrity": "sha512-MfSwg9JMBojMUoGjUmX+D2stoQj1CBYTCP0qnnVtu9A+YQXVKNtLjasYh+jozOcrb/wau8TCfWOkQTiOAruBog==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.10.1",
-                "@typescript-eslint/types": "5.10.1",
-                "@typescript-eslint/typescript-estree": "5.10.1",
+                "@typescript-eslint/scope-manager": "5.12.0",
+                "@typescript-eslint/types": "5.12.0",
+                "@typescript-eslint/typescript-estree": "5.12.0",
                 "debug": "^4.3.2"
             },
             "engines": {
@@ -12065,6 +12194,80 @@
                 "typescript": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.0.tgz",
+            "integrity": "sha512-GAMobtIJI8FGf1sLlUWNUm2IOkIjvn7laFWyRx7CLrv6nLBI7su+B7lbStqVlK5NdLvHRFiJo2HhiDF7Ki01WQ==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.12.0",
+                "@typescript-eslint/visitor-keys": "5.12.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.0.tgz",
+            "integrity": "sha512-JowqbwPf93nvf8fZn5XrPGFBdIK8+yx5UEGs2QFAYFI8IWYfrzz+6zqlurGr2ctShMaJxqwsqmra3WXWjH1nRQ==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.0.tgz",
+            "integrity": "sha512-Dd9gVeOqt38QHR0BEA8oRaT65WYqPYbIc5tRFQPkfLquVEFPD1HAtbZT98TLBkEcCkvwDYOAvuSvAD9DnQhMfQ==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.12.0",
+                "@typescript-eslint/visitor-keys": "5.12.0",
+                "debug": "^4.3.2",
+                "globby": "^11.0.4",
+                "is-glob": "^4.0.3",
+                "semver": "^7.3.5",
+                "tsutils": "^3.21.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.0.tgz",
+            "integrity": "sha512-cFwTlgnMV6TgezQynx2c/4/tx9Tufbuo9LPzmWqyRC3QC4qTGkAG1C6pBr0/4I10PAI/FlYunI3vJjIcu+ZHMg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.12.0",
+                "eslint-visitor-keys": "^3.0.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
@@ -12085,12 +12288,12 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.10.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz",
-            "integrity": "sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==",
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.12.0.tgz",
+            "integrity": "sha512-9j9rli3zEBV+ae7rlbBOotJcI6zfc6SHFMdKI9M3Nc0sy458LJ79Os+TPWeBBL96J9/e36rdJOfCuyRSgFAA0Q==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/utils": "5.10.1",
+                "@typescript-eslint/utils": "5.12.0",
                 "debug": "^4.3.2",
                 "tsutils": "^3.21.0"
             },
@@ -12108,6 +12311,126 @@
                 "typescript": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.0.tgz",
+            "integrity": "sha512-GAMobtIJI8FGf1sLlUWNUm2IOkIjvn7laFWyRx7CLrv6nLBI7su+B7lbStqVlK5NdLvHRFiJo2HhiDF7Ki01WQ==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.12.0",
+                "@typescript-eslint/visitor-keys": "5.12.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.0.tgz",
+            "integrity": "sha512-JowqbwPf93nvf8fZn5XrPGFBdIK8+yx5UEGs2QFAYFI8IWYfrzz+6zqlurGr2ctShMaJxqwsqmra3WXWjH1nRQ==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.0.tgz",
+            "integrity": "sha512-Dd9gVeOqt38QHR0BEA8oRaT65WYqPYbIc5tRFQPkfLquVEFPD1HAtbZT98TLBkEcCkvwDYOAvuSvAD9DnQhMfQ==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.12.0",
+                "@typescript-eslint/visitor-keys": "5.12.0",
+                "debug": "^4.3.2",
+                "globby": "^11.0.4",
+                "is-glob": "^4.0.3",
+                "semver": "^7.3.5",
+                "tsutils": "^3.21.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.12.0.tgz",
+            "integrity": "sha512-k4J2WovnMPGI4PzKgDtQdNrCnmBHpMUFy21qjX2CoPdoBcSBIMvVBr9P2YDP8jOqZOeK3ThOL6VO/sy6jtnvzw==",
+            "dev": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "@typescript-eslint/scope-manager": "5.12.0",
+                "@typescript-eslint/types": "5.12.0",
+                "@typescript-eslint/typescript-estree": "5.12.0",
+                "eslint-scope": "^5.1.1",
+                "eslint-utils": "^3.0.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.0.tgz",
+            "integrity": "sha512-cFwTlgnMV6TgezQynx2c/4/tx9Tufbuo9LPzmWqyRC3QC4qTGkAG1C6pBr0/4I10PAI/FlYunI3vJjIcu+ZHMg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.12.0",
+                "eslint-visitor-keys": "^3.0.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
@@ -12868,6 +13191,14 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/array-differ": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+            "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/array-flatten": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
@@ -12903,7 +13234,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -12983,7 +13313,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
             "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -13627,8 +13956,7 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "node_modules/base": {
             "version": "0.11.2",
@@ -13995,7 +14323,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -14968,8 +15295,7 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "node_modules/concat-stream": {
             "version": "1.6.2",
@@ -15669,7 +15995,6 @@
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
             "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-            "dev": true,
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -17009,7 +17334,6 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "dev": true,
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -17339,12 +17663,12 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
-            "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
+            "integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
             "dev": true,
             "dependencies": {
-                "@eslint/eslintrc": "^1.0.5",
+                "@eslint/eslintrc": "^1.1.0",
                 "@humanwhocodes/config-array": "^0.9.2",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
@@ -17352,10 +17676,10 @@
                 "debug": "^4.3.2",
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.1.0",
+                "eslint-scope": "^7.1.1",
                 "eslint-utils": "^3.0.0",
-                "eslint-visitor-keys": "^3.2.0",
-                "espree": "^9.3.0",
+                "eslint-visitor-keys": "^3.3.0",
+                "espree": "^9.3.1",
                 "esquery": "^1.4.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -17388,6 +17712,18 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-config-prettier": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.4.0.tgz",
+            "integrity": "sha512-CFotdUcMY18nGRo5KGsnNxpznzhkopOcOo0InID+sgQssPrzjvsyKZPvOgymTFeHrFuC3Tzdf2YndhXtULK9Iw==",
+            "dev": true,
+            "bin": {
+                "eslint-config-prettier": "bin/cli.js"
+            },
+            "peerDependencies": {
+                "eslint": ">=7.0.0"
             }
         },
         "node_modules/eslint-config-react-app": {
@@ -17722,6 +18058,32 @@
                 "semver": "bin/semver.js"
             }
         },
+        "node_modules/eslint-plugin-storybook": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.5.7.tgz",
+            "integrity": "sha512-rko/QUHa3/hrC3W5RmPrukKawCyGeVqSuwzyLZO6aV/neyOPrgkL/LED8u6NQJSaT1qZFT+7iLQ1eE8Ce7G+aA==",
+            "dev": true,
+            "dependencies": {
+                "@storybook/csf": "^0.0.1",
+                "@typescript-eslint/experimental-utils": "^5.3.0",
+                "requireindex": "^1.1.0"
+            },
+            "engines": {
+                "node": "12.x || 14.x || >= 16"
+            },
+            "peerDependencies": {
+                "eslint": ">=6"
+            }
+        },
+        "node_modules/eslint-plugin-storybook/node_modules/@storybook/csf": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.1.tgz",
+            "integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
+            "dev": true,
+            "dependencies": {
+                "lodash": "^4.17.15"
+            }
+        },
         "node_modules/eslint-plugin-testing-library": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.0.4.tgz",
@@ -17739,9 +18101,9 @@
             }
         },
         "node_modules/eslint-scope": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
-            "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+            "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
             "dev": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
@@ -17779,9 +18141,9 @@
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-            "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -17927,14 +18289,14 @@
             }
         },
         "node_modules/espree": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
-            "integrity": "sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==",
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+            "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
             "dev": true,
             "dependencies": {
                 "acorn": "^8.7.0",
                 "acorn-jsx": "^5.3.1",
-                "eslint-visitor-keys": "^3.1.0"
+                "eslint-visitor-keys": "^3.3.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -20242,7 +20604,6 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
             "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-            "dev": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -20929,7 +21290,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             },
@@ -21053,8 +21413,7 @@
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "node_modules/isobject": {
             "version": "4.0.0",
@@ -24007,8 +24366,7 @@
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -24103,7 +24461,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -24214,7 +24571,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -24420,6 +24776,14 @@
                 "rimraf": "bin.js"
             }
         },
+        "node_modules/mri": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -24443,6 +24807,21 @@
             "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
             "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
             "dev": true
+        },
+        "node_modules/multimatch": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+            "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+            "dependencies": {
+                "@types/minimatch": "^3.0.3",
+                "array-differ": "^3.0.0",
+                "array-union": "^2.1.0",
+                "arrify": "^2.0.1",
+                "minimatch": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/nan": {
             "version": "2.15.0",
@@ -24890,7 +25269,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
             "dependencies": {
                 "path-key": "^3.0.0"
             },
@@ -27539,7 +27917,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -27548,7 +27925,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
             "dependencies": {
                 "mimic-fn": "^2.1.0"
             },
@@ -27793,7 +28169,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -27963,7 +28338,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -27981,7 +28355,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -29568,7 +29941,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
             "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
-            "dev": true,
             "bin": {
                 "prettier": "bin-prettier.js"
             },
@@ -29637,6 +30009,181 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/pretty-quick": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-3.1.3.tgz",
+            "integrity": "sha512-kOCi2FJabvuh1as9enxYmrnBC6tVMoVOenMaBqRfsvBHB0cbpYHjdQEpSglpASDFEXVwplpcGR4CLEaisYAFcA==",
+            "dependencies": {
+                "chalk": "^3.0.0",
+                "execa": "^4.0.0",
+                "find-up": "^4.1.0",
+                "ignore": "^5.1.4",
+                "mri": "^1.1.5",
+                "multimatch": "^4.0.0"
+            },
+            "bin": {
+                "pretty-quick": "bin/pretty-quick.js"
+            },
+            "engines": {
+                "node": ">=10.13"
+            },
+            "peerDependencies": {
+                "prettier": ">=2.0.0"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/chalk": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/pretty-quick/node_modules/execa": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+            "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+            "dependencies": {
+                "cross-spawn": "^7.0.0",
+                "get-stream": "^5.0.0",
+                "human-signals": "^1.1.1",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.0",
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/get-stream": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+            "dependencies": {
+                "pump": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/human-signals": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+            "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+            "engines": {
+                "node": ">=8.12.0"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/prismjs": {
@@ -29816,7 +30363,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "dev": true,
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -31183,6 +31729,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/requireindex": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+            "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.5"
+            }
+        },
         "node_modules/requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -32251,7 +32806,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -32263,7 +32817,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -32291,8 +32844,7 @@
         "node_modules/signal-exit": {
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-            "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
-            "dev": true
+            "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
         },
         "node_modules/signale": {
             "version": "1.4.0",
@@ -33112,7 +33664,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -35782,7 +36333,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -36203,8 +36753,7 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "node_modules/write-file-atomic": {
             "version": "3.0.3",
@@ -37964,14 +38513,14 @@
             "dev": true
         },
         "@eslint/eslintrc": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
-            "integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
+            "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.2.0",
+                "espree": "^9.3.1",
                 "globals": "^13.9.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.2.1",
@@ -37987,9 +38536,9 @@
                     "dev": true
                 },
                 "globals": {
-                    "version": "13.12.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-                    "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+                    "version": "13.12.1",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
+                    "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
                     "dev": true,
                     "requires": {
                         "type-fest": "^0.20.2"
@@ -44933,8 +45482,7 @@
         "@types/minimatch": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-            "dev": true
+            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
         },
         "@types/minimist": {
             "version": "1.2.2",
@@ -45241,20 +45789,93 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "5.10.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz",
-            "integrity": "sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==",
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.12.0.tgz",
+            "integrity": "sha512-fwCMkDimwHVeIOKeBHiZhRUfJXU8n6xW1FL9diDxAyGAFvKcH4csy0v7twivOQdQdA0KC8TDr7GGRd3L4Lv0rQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.10.1",
-                "@typescript-eslint/type-utils": "5.10.1",
-                "@typescript-eslint/utils": "5.10.1",
+                "@typescript-eslint/scope-manager": "5.12.0",
+                "@typescript-eslint/type-utils": "5.12.0",
+                "@typescript-eslint/utils": "5.12.0",
                 "debug": "^4.3.2",
                 "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.1.8",
                 "regexpp": "^3.2.0",
                 "semver": "^7.3.5",
                 "tsutils": "^3.21.0"
+            },
+            "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "5.12.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.0.tgz",
+                    "integrity": "sha512-GAMobtIJI8FGf1sLlUWNUm2IOkIjvn7laFWyRx7CLrv6nLBI7su+B7lbStqVlK5NdLvHRFiJo2HhiDF7Ki01WQ==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.12.0",
+                        "@typescript-eslint/visitor-keys": "5.12.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "5.12.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.0.tgz",
+                    "integrity": "sha512-JowqbwPf93nvf8fZn5XrPGFBdIK8+yx5UEGs2QFAYFI8IWYfrzz+6zqlurGr2ctShMaJxqwsqmra3WXWjH1nRQ==",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "5.12.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.0.tgz",
+                    "integrity": "sha512-Dd9gVeOqt38QHR0BEA8oRaT65WYqPYbIc5tRFQPkfLquVEFPD1HAtbZT98TLBkEcCkvwDYOAvuSvAD9DnQhMfQ==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.12.0",
+                        "@typescript-eslint/visitor-keys": "5.12.0",
+                        "debug": "^4.3.2",
+                        "globby": "^11.0.4",
+                        "is-glob": "^4.0.3",
+                        "semver": "^7.3.5",
+                        "tsutils": "^3.21.0"
+                    }
+                },
+                "@typescript-eslint/utils": {
+                    "version": "5.12.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.12.0.tgz",
+                    "integrity": "sha512-k4J2WovnMPGI4PzKgDtQdNrCnmBHpMUFy21qjX2CoPdoBcSBIMvVBr9P2YDP8jOqZOeK3ThOL6VO/sy6jtnvzw==",
+                    "dev": true,
+                    "requires": {
+                        "@types/json-schema": "^7.0.9",
+                        "@typescript-eslint/scope-manager": "5.12.0",
+                        "@typescript-eslint/types": "5.12.0",
+                        "@typescript-eslint/typescript-estree": "5.12.0",
+                        "eslint-scope": "^5.1.1",
+                        "eslint-utils": "^3.0.0"
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "5.12.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.0.tgz",
+                    "integrity": "sha512-cFwTlgnMV6TgezQynx2c/4/tx9Tufbuo9LPzmWqyRC3QC4qTGkAG1C6pBr0/4I10PAI/FlYunI3vJjIcu+ZHMg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.12.0",
+                        "eslint-visitor-keys": "^3.0.0"
+                    }
+                },
+                "eslint-scope": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+                    "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+                    "dev": true,
+                    "requires": {
+                        "esrecurse": "^4.3.0",
+                        "estraverse": "^4.1.1"
+                    }
+                },
+                "estraverse": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+                    "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+                    "dev": true
+                }
             }
         },
         "@typescript-eslint/experimental-utils": {
@@ -45267,15 +45888,58 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "5.10.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
-            "integrity": "sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==",
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.12.0.tgz",
+            "integrity": "sha512-MfSwg9JMBojMUoGjUmX+D2stoQj1CBYTCP0qnnVtu9A+YQXVKNtLjasYh+jozOcrb/wau8TCfWOkQTiOAruBog==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.10.1",
-                "@typescript-eslint/types": "5.10.1",
-                "@typescript-eslint/typescript-estree": "5.10.1",
+                "@typescript-eslint/scope-manager": "5.12.0",
+                "@typescript-eslint/types": "5.12.0",
+                "@typescript-eslint/typescript-estree": "5.12.0",
                 "debug": "^4.3.2"
+            },
+            "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "5.12.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.0.tgz",
+                    "integrity": "sha512-GAMobtIJI8FGf1sLlUWNUm2IOkIjvn7laFWyRx7CLrv6nLBI7su+B7lbStqVlK5NdLvHRFiJo2HhiDF7Ki01WQ==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.12.0",
+                        "@typescript-eslint/visitor-keys": "5.12.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "5.12.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.0.tgz",
+                    "integrity": "sha512-JowqbwPf93nvf8fZn5XrPGFBdIK8+yx5UEGs2QFAYFI8IWYfrzz+6zqlurGr2ctShMaJxqwsqmra3WXWjH1nRQ==",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "5.12.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.0.tgz",
+                    "integrity": "sha512-Dd9gVeOqt38QHR0BEA8oRaT65WYqPYbIc5tRFQPkfLquVEFPD1HAtbZT98TLBkEcCkvwDYOAvuSvAD9DnQhMfQ==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.12.0",
+                        "@typescript-eslint/visitor-keys": "5.12.0",
+                        "debug": "^4.3.2",
+                        "globby": "^11.0.4",
+                        "is-glob": "^4.0.3",
+                        "semver": "^7.3.5",
+                        "tsutils": "^3.21.0"
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "5.12.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.0.tgz",
+                    "integrity": "sha512-cFwTlgnMV6TgezQynx2c/4/tx9Tufbuo9LPzmWqyRC3QC4qTGkAG1C6pBr0/4I10PAI/FlYunI3vJjIcu+ZHMg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.12.0",
+                        "eslint-visitor-keys": "^3.0.0"
+                    }
+                }
             }
         },
         "@typescript-eslint/scope-manager": {
@@ -45289,14 +45953,87 @@
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "5.10.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz",
-            "integrity": "sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==",
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.12.0.tgz",
+            "integrity": "sha512-9j9rli3zEBV+ae7rlbBOotJcI6zfc6SHFMdKI9M3Nc0sy458LJ79Os+TPWeBBL96J9/e36rdJOfCuyRSgFAA0Q==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/utils": "5.10.1",
+                "@typescript-eslint/utils": "5.12.0",
                 "debug": "^4.3.2",
                 "tsutils": "^3.21.0"
+            },
+            "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "5.12.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.0.tgz",
+                    "integrity": "sha512-GAMobtIJI8FGf1sLlUWNUm2IOkIjvn7laFWyRx7CLrv6nLBI7su+B7lbStqVlK5NdLvHRFiJo2HhiDF7Ki01WQ==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.12.0",
+                        "@typescript-eslint/visitor-keys": "5.12.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "5.12.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.0.tgz",
+                    "integrity": "sha512-JowqbwPf93nvf8fZn5XrPGFBdIK8+yx5UEGs2QFAYFI8IWYfrzz+6zqlurGr2ctShMaJxqwsqmra3WXWjH1nRQ==",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "5.12.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.0.tgz",
+                    "integrity": "sha512-Dd9gVeOqt38QHR0BEA8oRaT65WYqPYbIc5tRFQPkfLquVEFPD1HAtbZT98TLBkEcCkvwDYOAvuSvAD9DnQhMfQ==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.12.0",
+                        "@typescript-eslint/visitor-keys": "5.12.0",
+                        "debug": "^4.3.2",
+                        "globby": "^11.0.4",
+                        "is-glob": "^4.0.3",
+                        "semver": "^7.3.5",
+                        "tsutils": "^3.21.0"
+                    }
+                },
+                "@typescript-eslint/utils": {
+                    "version": "5.12.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.12.0.tgz",
+                    "integrity": "sha512-k4J2WovnMPGI4PzKgDtQdNrCnmBHpMUFy21qjX2CoPdoBcSBIMvVBr9P2YDP8jOqZOeK3ThOL6VO/sy6jtnvzw==",
+                    "dev": true,
+                    "requires": {
+                        "@types/json-schema": "^7.0.9",
+                        "@typescript-eslint/scope-manager": "5.12.0",
+                        "@typescript-eslint/types": "5.12.0",
+                        "@typescript-eslint/typescript-estree": "5.12.0",
+                        "eslint-scope": "^5.1.1",
+                        "eslint-utils": "^3.0.0"
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "5.12.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.0.tgz",
+                    "integrity": "sha512-cFwTlgnMV6TgezQynx2c/4/tx9Tufbuo9LPzmWqyRC3QC4qTGkAG1C6pBr0/4I10PAI/FlYunI3vJjIcu+ZHMg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.12.0",
+                        "eslint-visitor-keys": "^3.0.0"
+                    }
+                },
+                "eslint-scope": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+                    "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+                    "dev": true,
+                    "requires": {
+                        "esrecurse": "^4.3.0",
+                        "estraverse": "^4.1.1"
+                    }
+                },
+                "estraverse": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+                    "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+                    "dev": true
+                }
             }
         },
         "@typescript-eslint/types": {
@@ -45916,6 +46653,11 @@
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
             "dev": true
         },
+        "array-differ": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+            "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg=="
+        },
         "array-flatten": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
@@ -45944,8 +46686,7 @@
         "array-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -45997,8 +46738,7 @@
         "arrify": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-            "dev": true
+            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
         },
         "asap": {
             "version": "2.0.6",
@@ -46525,8 +47265,7 @@
         "balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "base": {
             "version": "0.11.2",
@@ -46818,7 +47557,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -47605,8 +48343,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "concat-stream": {
             "version": "1.6.2",
@@ -48187,7 +48924,6 @@
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
             "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-            "dev": true,
             "requires": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -49252,7 +49988,6 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "dev": true,
             "requires": {
                 "once": "^1.4.0"
             }
@@ -49522,12 +50257,12 @@
             }
         },
         "eslint": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
-            "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
+            "integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
             "dev": true,
             "requires": {
-                "@eslint/eslintrc": "^1.0.5",
+                "@eslint/eslintrc": "^1.1.0",
                 "@humanwhocodes/config-array": "^0.9.2",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
@@ -49535,10 +50270,10 @@
                 "debug": "^4.3.2",
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.1.0",
+                "eslint-scope": "^7.1.1",
                 "eslint-utils": "^3.0.0",
-                "eslint-visitor-keys": "^3.2.0",
-                "espree": "^9.3.0",
+                "eslint-visitor-keys": "^3.3.0",
+                "espree": "^9.3.1",
                 "esquery": "^1.4.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -49644,6 +50379,13 @@
                     }
                 }
             }
+        },
+        "eslint-config-prettier": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.4.0.tgz",
+            "integrity": "sha512-CFotdUcMY18nGRo5KGsnNxpznzhkopOcOo0InID+sgQssPrzjvsyKZPvOgymTFeHrFuC3Tzdf2YndhXtULK9Iw==",
+            "dev": true,
+            "requires": {}
         },
         "eslint-config-react-app": {
             "version": "7.0.0",
@@ -49900,6 +50642,28 @@
             "dev": true,
             "requires": {}
         },
+        "eslint-plugin-storybook": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.5.7.tgz",
+            "integrity": "sha512-rko/QUHa3/hrC3W5RmPrukKawCyGeVqSuwzyLZO6aV/neyOPrgkL/LED8u6NQJSaT1qZFT+7iLQ1eE8Ce7G+aA==",
+            "dev": true,
+            "requires": {
+                "@storybook/csf": "^0.0.1",
+                "@typescript-eslint/experimental-utils": "^5.3.0",
+                "requireindex": "^1.1.0"
+            },
+            "dependencies": {
+                "@storybook/csf": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.1.tgz",
+                    "integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "^4.17.15"
+                    }
+                }
+            }
+        },
         "eslint-plugin-testing-library": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.0.4.tgz",
@@ -49910,9 +50674,9 @@
             }
         },
         "eslint-scope": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
-            "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+            "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
             "dev": true,
             "requires": {
                 "esrecurse": "^4.3.0",
@@ -49937,9 +50701,9 @@
             }
         },
         "eslint-visitor-keys": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-            "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
             "dev": true
         },
         "eslint-webpack-plugin": {
@@ -49956,14 +50720,14 @@
             }
         },
         "espree": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
-            "integrity": "sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==",
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+            "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
             "dev": true,
             "requires": {
                 "acorn": "^8.7.0",
                 "acorn-jsx": "^5.3.1",
-                "eslint-visitor-keys": "^3.1.0"
+                "eslint-visitor-keys": "^3.3.0"
             }
         },
         "esprima": {
@@ -51739,8 +52503,7 @@
         "ignore": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-            "dev": true
+            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
         },
         "immer": {
             "version": "9.0.12",
@@ -52230,8 +52993,7 @@
         "is-stream": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "dev": true
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
         },
         "is-string": {
             "version": "1.0.7",
@@ -52317,8 +53079,7 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
             "version": "4.0.0",
@@ -54553,8 +55314,7 @@
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
         },
         "merge2": {
             "version": "1.4.1",
@@ -54626,8 +55386,7 @@
         "mimic-fn": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
         },
         "min-document": {
             "version": "2.19.0",
@@ -54710,7 +55469,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -54877,6 +55635,11 @@
                 }
             }
         },
+        "mri": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
+        },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -54897,6 +55660,18 @@
             "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
             "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
             "dev": true
+        },
+        "multimatch": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+            "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+            "requires": {
+                "@types/minimatch": "^3.0.3",
+                "array-differ": "^3.0.0",
+                "array-union": "^2.1.0",
+                "arrify": "^2.0.1",
+                "minimatch": "^3.0.4"
+            }
         },
         "nan": {
             "version": "2.15.0",
@@ -56907,7 +57682,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
             "requires": {
                 "path-key": "^3.0.0"
             }
@@ -57140,7 +57914,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -57149,7 +57922,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
             "requires": {
                 "mimic-fn": "^2.1.0"
             }
@@ -57319,8 +58091,7 @@
         "p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "dev": true
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
         },
         "pako": {
             "version": "1.0.11",
@@ -57473,8 +58244,7 @@
         "path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         },
         "path-is-absolute": {
             "version": "1.0.1",
@@ -57485,8 +58255,7 @@
         "path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
         },
         "path-parse": {
             "version": "1.0.7",
@@ -58559,8 +59328,7 @@
         "prettier": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
-            "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
-            "dev": true
+            "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w=="
         },
         "pretty-bytes": {
             "version": "5.6.0",
@@ -58608,6 +59376,126 @@
             "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
             "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
             "dev": true
+        },
+        "pretty-quick": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-3.1.3.tgz",
+            "integrity": "sha512-kOCi2FJabvuh1as9enxYmrnBC6tVMoVOenMaBqRfsvBHB0cbpYHjdQEpSglpASDFEXVwplpcGR4CLEaisYAFcA==",
+            "requires": {
+                "chalk": "^3.0.0",
+                "execa": "^4.0.0",
+                "find-up": "^4.1.0",
+                "ignore": "^5.1.4",
+                "mri": "^1.1.5",
+                "multimatch": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+                },
+                "execa": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+                    "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+                    "requires": {
+                        "cross-spawn": "^7.0.0",
+                        "get-stream": "^5.0.0",
+                        "human-signals": "^1.1.1",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.0",
+                        "onetime": "^5.1.0",
+                        "signal-exit": "^3.0.2",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+                },
+                "human-signals": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+                    "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
         },
         "prismjs": {
             "version": "1.26.0",
@@ -58759,7 +59647,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "dev": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -59819,6 +60706,12 @@
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true
         },
+        "requireindex": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+            "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+            "dev": true
+        },
         "requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -60661,7 +61554,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
             "requires": {
                 "shebang-regex": "^3.0.0"
             }
@@ -60669,8 +61561,7 @@
         "shebang-regex": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
         },
         "shell-quote": {
             "version": "1.7.3",
@@ -60692,8 +61583,7 @@
         "signal-exit": {
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-            "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
-            "dev": true
+            "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
         },
         "signale": {
             "version": "1.4.0",
@@ -61394,8 +62284,7 @@
         "strip-final-newline": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "dev": true
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
         },
         "strip-indent": {
             "version": "3.0.0",
@@ -63442,7 +64331,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
@@ -63818,8 +64706,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "write-file-atomic": {
             "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "private": true,
     "main": "lib",
     "dependencies": {
+        "pretty-quick": "^3.1.3",
         "styled-components": "^5.3.3",
         "web-vitals": "^2.1.4"
     },
@@ -22,10 +23,12 @@
         "build": "npm run build-storybook",
         "build-ts": "tsc --declaration",
         "prepare": "npm run build-ts",
+        "prettify-staged": "pretty-quick --staged --pattern \"src/**/*{.ts,.tsx}\" --verbose",
         "pre-commit-msg": "echo \"Verifying build ...\""
     },
     "pre-commit": [
         "pre-commit-msg",
+        "prettify-staged",
         "build-ts"
     ],
     "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -22,13 +22,17 @@
         "dev": "npm run storybook",
         "build": "npm run build-storybook",
         "build-ts": "tsc --declaration",
+        "tslint": "eslint .",
         "prepare": "npm run build-ts",
+        "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
+        "prettier-check": "prettier  --config ./.prettierrc --check \"src/**/*{.ts,.tsx}\"",
         "prettify-staged": "pretty-quick --staged --pattern \"src/**/*{.ts,.tsx}\" --verbose",
         "pre-commit-msg": "echo \"Verifying build ...\""
     },
     "pre-commit": [
         "pre-commit-msg",
         "prettify-staged",
+        "lint",
         "build-ts"
     ],
     "eslintConfig": {
@@ -76,6 +80,15 @@
         "@types/react": "^17.0.38",
         "@types/react-dom": "^17.0.11",
         "@types/styled-components": "^5.1.21",
+        "@typescript-eslint/eslint-plugin": "^5.12.0",
+        "@typescript-eslint/parser": "^5.12.0",
+        "eslint": "^8.9.0",
+        "eslint-config-prettier": "^8.4.0",
+        "eslint-plugin-import": "^2.25.4",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-react": "^7.28.0",
+        "eslint-plugin-react-hooks": "^4.3.0",
+        "eslint-plugin-storybook": "^0.5.7",
         "pre-commit": "^1.2.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "tslint": "eslint .",
         "prepare": "npm run build-ts",
         "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
+        "prettier-write": "prettier  --config ./.prettierrc --write \"src/**/*{.ts,.tsx}\"",
         "prettier-check": "prettier  --config ./.prettierrc --check \"src/**/*{.ts,.tsx}\"",
         "prettify-staged": "pretty-quick --staged --pattern \"src/**/*{.ts,.tsx}\" --verbose",
         "pre-commit-msg": "echo \"Verifying build ...\""

--- a/src/stories/Forms/Button/Button.stories.tsx
+++ b/src/stories/Forms/Button/Button.stories.tsx
@@ -3,16 +3,16 @@ import { Button } from '.';
 export default { component: Button };
 
 export const Primary = {
-    args: {
-        type: 'button',
-        children: 'Click me',
-    },
+  args: {
+    type: 'button',
+    children: 'Click me',
+  },
 };
 
 export const Secondary = {
-    args: {
-        type: 'button',
-        children: 'Click me',
-        secondary: true,
-    },
+  args: {
+    type: 'button',
+    children: 'Click me',
+    secondary: true,
+  },
 };

--- a/src/stories/Forms/Button/index.tsx
+++ b/src/stories/Forms/Button/index.tsx
@@ -2,61 +2,61 @@ import React from 'react';
 import styled from 'styled-components';
 
 const ButtonElement = styled.button<ButtonProps>`
-    border: solid 2px ${(p) => `var(--color-${p.color})`};
-    border-radius: 30px;
-    padding: 0 var(--spacing-24);
-    height: 38px;
-    background: ${(p) =>
-        p.secondary ? 'var(--color-white)' : `var(--color-${p.color})`};
-    color: ${(p) =>
-        p.secondary ? `var(--color-${p.color})` : 'var(--color-white)'};
-    font-weight: bold;
-    font-family: var(--font-family);
+  border: solid 2px ${(p) => `var(--color-${p.color})`};
+  border-radius: 30px;
+  padding: 0 var(--spacing-24);
+  height: 38px;
+  background: ${(p) =>
+    p.secondary ? 'var(--color-white)' : `var(--color-${p.color})`};
+  color: ${(p) =>
+    p.secondary ? `var(--color-${p.color})` : 'var(--color-white)'};
+  font-weight: bold;
+  font-family: var(--font-family);
 `;
 
 const roleToHtmlTag = {
-    button: 'button',
-    submit: 'input',
-    anchor: 'a',
+  button: 'button',
+  submit: 'input',
+  anchor: 'a',
 };
 export interface ButtonProps {
-    disabled?: boolean;
-    label?: string;
-    onClick?: () => void;
-    role?: 'button' | 'submit' | 'anchor';
-    secondary?: boolean;
-    color?: 'black' | 'lavender';
-    children?: React.ReactNode;
-    href?: string;
+  disabled?: boolean;
+  label?: string;
+  onClick?: () => void;
+  role?: 'button' | 'submit' | 'anchor';
+  secondary?: boolean;
+  color?: 'black' | 'lavender';
+  children?: React.ReactNode;
+  href?: string;
 }
 
 /**
  * Button component
  */
 export const Button = ({
-    children,
-    disabled,
-    label,
-    onClick,
-    role = 'button',
-    color = 'black',
-    secondary,
-    href,
+  children,
+  disabled,
+  label,
+  onClick,
+  role = 'button',
+  color = 'black',
+  secondary,
+  href,
 }: ButtonProps) => {
-    const isSubmit = role === 'submit';
-    return (
-        <ButtonElement
-            as={roleToHtmlTag[role] as any}
-            disabled={disabled}
-            onClick={onClick}
-            type={isSubmit ? 'submit' : undefined}
-            color={color}
-            secondary={secondary}
-            href={href}
-        >
-            {label && isSubmit ? label : children}
-        </ButtonElement>
-    );
+  const isSubmit = role === 'submit';
+  return (
+    <ButtonElement
+      as={roleToHtmlTag[role] as any}
+      disabled={disabled}
+      onClick={onClick}
+      type={isSubmit ? 'submit' : undefined}
+      color={color}
+      secondary={secondary}
+      href={href}
+    >
+      {label && isSubmit ? label : children}
+    </ButtonElement>
+  );
 };
 
 export default Button;

--- a/src/stories/Forms/Input/Input.stories.tsx
+++ b/src/stories/Forms/Input/Input.stories.tsx
@@ -3,9 +3,9 @@ import { Input } from '.';
 export default { component: Input };
 
 export const Primary = {
-    args: {
-        type: 'text',
-        label: 'Your name',
-        isRequired: true,
-    },
+  args: {
+    type: 'text',
+    label: 'Your name',
+    isRequired: true,
+  },
 };

--- a/src/stories/Forms/Input/index.tsx
+++ b/src/stories/Forms/Input/index.tsx
@@ -2,8 +2,8 @@ import React, { useState, useRef } from 'react';
 import styled from 'styled-components';
 
 interface WrapperProps {
-    focused: boolean;
-    expanded: boolean;
+  focused: boolean;
+  expanded: boolean;
 }
 
 /**
@@ -12,108 +12,108 @@ interface WrapperProps {
  * Add color variations
  */
 const Wrapper = styled.div<WrapperProps>`
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    max-width: 600px;
-    height: 56px;
-    margin-bottom: 1rem;
-    padding: 0 15px;
-    border-radius: 6px;
-    font-size: 16px;
-    cursor: text;
-    transition: all 0.2s ease-in-out;
-    background-color: rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  max-width: 600px;
+  height: 56px;
+  margin-bottom: 1rem;
+  padding: 0 15px;
+  border-radius: 6px;
+  font-size: 16px;
+  cursor: text;
+  transition: all 0.2s ease-in-out;
+  background-color: rgba(0, 0, 0, 0.3);
 
-    ${({ focused, expanded }) =>
-        (focused || expanded) &&
-        `border: 1px solid black; 
+  ${({ focused, expanded }) =>
+    (focused || expanded) &&
+    `border: 1px solid black; 
         background-color: var(--color-white);`}
 
-    label {
-        cursor: inherit;
-        transition: inherit;
+  label {
+    cursor: inherit;
+    transition: inherit;
 
-        ${({ focused, expanded }) =>
-            (focused || expanded) &&
-            `font-size: 12px;
+    ${({ focused, expanded }) =>
+      (focused || expanded) &&
+      `font-size: 12px;
             font-weight: bold;`}
 
-        // required text
+    // required text
         i {
-            font-style: normal;
-            font-size: 12px;
-            font-weight: normal;
-            padding-left: 5px;
-        }
+      font-style: normal;
+      font-size: 12px;
+      font-weight: normal;
+      padding-left: 5px;
     }
+  }
 
-    input {
-        all: unset;
-        display: block;
-        height: 0;
-        transition: inherit;
-        will-change: height;
+  input {
+    all: unset;
+    display: block;
+    height: 0;
+    transition: inherit;
+    will-change: height;
 
-        ${({ focused, expanded }) => (focused || expanded) && `height: 1.25em;`}
-    }
+    ${({ focused, expanded }) => (focused || expanded) && `height: 1.25em;`}
+  }
 `;
 
 export interface InputProps {
-    /**
-     * Input type
-     */
-    type: string;
+  /**
+   * Input type
+   */
+  type: string;
 
-    /**
-     * Label text
-     */
-    label?: string;
+  /**
+   * Label text
+   */
+  label?: string;
 
-    /**
-     * Is input required?
-     */
-    isRequired?: boolean;
+  /**
+   * Is input required?
+   */
+  isRequired?: boolean;
 }
 
 /**
  * Input component
  */
 export const Input = ({ type, label, isRequired }: InputProps) => {
-    const [focused, setFocused] = useState(false);
-    const [expanded, setExpanded] = useState(false);
-    const inputRef = useRef<HTMLInputElement>(null);
+  const [focused, setFocused] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-    const onFocus = () => setFocused(true);
-    const onBlur = () => setFocused(false);
+  const onFocus = () => setFocused(true);
+  const onBlur = () => setFocused(false);
 
-    const handleInput = () => {
-        if (!inputRef.current) return;
-        setExpanded(inputRef.current.value.length > 0);
-    };
+  const handleInput = () => {
+    if (!inputRef.current) return;
+    setExpanded(inputRef.current.value.length > 0);
+  };
 
-    return (
-        <Wrapper
-            focused={focused}
-            expanded={expanded}
-            onClick={() => inputRef?.current?.focus()}
-        >
-            {label && (
-                <label>
-                    {label}
-                    {!isRequired && <i>(optional)</i>}
-                </label>
-            )}
-            <input
-                type={type}
-                required={isRequired}
-                onFocus={onFocus}
-                onBlur={onBlur}
-                onChange={handleInput}
-                ref={inputRef}
-            />
-        </Wrapper>
-    );
+  return (
+    <Wrapper
+      focused={focused}
+      expanded={expanded}
+      onClick={() => inputRef?.current?.focus()}
+    >
+      {label && (
+        <label>
+          {label}
+          {!isRequired && <i>(optional)</i>}
+        </label>
+      )}
+      <input
+        type={type}
+        required={isRequired}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onChange={handleInput}
+        ref={inputRef}
+      />
+    </Wrapper>
+  );
 };
 
 export default Input;

--- a/src/stories/Forms/TextArea/Textarea.stories.tsx
+++ b/src/stories/Forms/TextArea/Textarea.stories.tsx
@@ -3,9 +3,9 @@ import { TextArea } from '.';
 export default { component: TextArea };
 
 export const Primary = {
-    args: {
-        label: 'Your message',
-        isRequired: true,
-        baseHeight: 136,
-    },
+  args: {
+    label: 'Your message',
+    isRequired: true,
+    baseHeight: 136,
+  },
 };

--- a/src/stories/Forms/TextArea/index.tsx
+++ b/src/stories/Forms/TextArea/index.tsx
@@ -2,9 +2,9 @@ import React, { useState, useRef } from 'react';
 import styled from 'styled-components';
 
 interface WrapperProps {
-    focused: boolean;
-    expanded: boolean;
-    height: number;
+  focused: boolean;
+  expanded: boolean;
+  height: number;
 }
 
 /**
@@ -13,132 +13,132 @@ interface WrapperProps {
  * Add color variations
  */
 const Wrapper = styled.div<WrapperProps>`
-    display: flex;
-    flex-direction: column;
-    max-width: 600px;
-    height: ${({ height }) => `${height}px`};
-    margin-bottom: 1rem;
-    padding: 15px;
-    border-radius: 6px;
-    font-size: 16px;
-    cursor: text;
-    background-color: rgba(0, 0, 0, 0.3);
-    transition: all 0.2s ease-in-out, height 0s;
-    will-change: height;
+  display: flex;
+  flex-direction: column;
+  max-width: 600px;
+  height: ${({ height }) => `${height}px`};
+  margin-bottom: 1rem;
+  padding: 15px;
+  border-radius: 6px;
+  font-size: 16px;
+  cursor: text;
+  background-color: rgba(0, 0, 0, 0.3);
+  transition: all 0.2s ease-in-out, height 0s;
+  will-change: height;
 
-    ${({ focused, expanded }) =>
-        (focused || expanded) &&
-        `padding-top: 10px;
+  ${({ focused, expanded }) =>
+    (focused || expanded) &&
+    `padding-top: 10px;
         border: 1px solid black; 
         background-color: var(--color-white);
         `}
 
-    label {
-        padding-bottom: 5px;
-        cursor: inherit;
-        transition: inherit;
+  label {
+    padding-bottom: 5px;
+    cursor: inherit;
+    transition: inherit;
 
-        ${({ focused, expanded }) =>
-            (focused || expanded) &&
-            `font-size: 12px;
+    ${({ focused, expanded }) =>
+      (focused || expanded) &&
+      `font-size: 12px;
             font-weight: bold;`}
 
-        // Required text
+    // Required text
         i {
-            padding-left: 5px;
-            font-style: normal;
-            font-weight: normal;
-            font-size: 12px;
-        }
+      padding-left: 5px;
+      font-style: normal;
+      font-weight: normal;
+      font-size: 12px;
     }
+  }
 
-    textarea {
-        all: unset;
-        flex-grow: 1;
-        overflow: hidden;
-        word-wrap: break-word;
-        resize: none;
-    }
+  textarea {
+    all: unset;
+    flex-grow: 1;
+    overflow: hidden;
+    word-wrap: break-word;
+    resize: none;
+  }
 `;
 
 export interface TextAreaProps {
-    /**
-     * Label text
-     */
-    label?: string;
+  /**
+   * Label text
+   */
+  label?: string;
 
-    /**
-     * Is input required?
-     */
-    isRequired?: boolean;
+  /**
+   * Is input required?
+   */
+  isRequired?: boolean;
 
-    /**
-     * TextArea height in px.
-     * @default '136'
-     */
-    baseHeight?: number;
+  /**
+   * TextArea height in px.
+   * @default '136'
+   */
+  baseHeight?: number;
 }
 
 /**
  * TextArea component
  */
 export const TextArea = ({
-    label,
-    isRequired,
-    baseHeight = 136,
+  label,
+  isRequired,
+  baseHeight = 136,
 }: TextAreaProps) => {
-    const [focused, setFocused] = useState(false);
-    const [expanded, setExpanded] = useState(false);
-    const [height, setHeight] = useState(baseHeight);
-    const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [focused, setFocused] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const [height, setHeight] = useState(baseHeight);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-    const onFocus = () => setFocused(true);
-    const onBlur = () => setFocused(false);
+  const onFocus = () => setFocused(true);
+  const onBlur = () => setFocused(false);
 
-    const handleTextArea = () => {
-        if (!textareaRef.current) return;
-        // Set expanded state to true if textarea has content
-        setExpanded(textareaRef.current.value.length > 0);
+  const handleTextArea = () => {
+    if (!textareaRef.current) return;
+    // Set expanded state to true if textarea has content
+    setExpanded(textareaRef.current.value.length > 0);
 
-        // Set height of the textarea to the content height
-        const calcHeight = getTextAreaHeight();
-        setHeight(calcHeight > baseHeight ? calcHeight : baseHeight);
-    };
+    // Set height of the textarea to the content height
+    const calcHeight = getTextAreaHeight();
+    setHeight(calcHeight > baseHeight ? calcHeight : baseHeight);
+  };
 
-    /**
-     * Set height to auto to allow the textarea to expand
-     */
-    const getTextAreaHeight = (): number => {
-        if (!textareaRef.current) return 0;
-        const textarea = textareaRef.current;
-        const wrapperHeight = textarea.parentElement?.clientHeight || 0;
-        const textareaHeight = textarea.clientHeight || 0;
-        const contentHeight = textarea.scrollHeight;
-        return wrapperHeight - textareaHeight + contentHeight;
-    };
+  /**
+   * Set height to auto to allow the textarea to expand
+   */
+  const getTextAreaHeight = (): number => {
+    if (!textareaRef.current) return 0;
+    const textarea = textareaRef.current;
+    const wrapperHeight = textarea.parentElement?.clientHeight || 0;
+    const textareaHeight = textarea.clientHeight || 0;
+    const contentHeight = textarea.scrollHeight;
+    return wrapperHeight - textareaHeight + contentHeight;
+  };
 
-    return (
-        <Wrapper
-            focused={focused}
-            expanded={expanded}
-            height={height}
-            onClick={() => textareaRef?.current?.focus()}
-        >
-            {label && (
-                <label>
-                    {label}
-                    {!isRequired && <i>(optional)</i>}
-                </label>
-            )}
-            <textarea
-                required={isRequired}
-                onFocus={onFocus}
-                onBlur={onBlur}
-                onChange={handleTextArea}
-                ref={textareaRef}
-            ></textarea>
-        </Wrapper>
-    );
+  return (
+    <Wrapper
+      focused={focused}
+      expanded={expanded}
+      height={height}
+      onClick={() => textareaRef?.current?.focus()}
+    >
+      {label && (
+        <label>
+          {label}
+          {!isRequired && <i>(optional)</i>}
+        </label>
+      )}
+      <textarea
+        required={isRequired}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onChange={handleTextArea}
+        ref={textareaRef}
+      ></textarea>
+    </Wrapper>
+  );
 };
 
 export default TextArea;

--- a/src/stories/Foundation/Badge/Badge.stories.tsx
+++ b/src/stories/Foundation/Badge/Badge.stories.tsx
@@ -9,26 +9,26 @@ export default { component: Badge };
  * It renders the Badge, and that's about it.
  */
 export const Primary = {
-    args: {
-        children: 'Badge',
-    },
+  args: {
+    children: 'Badge',
+  },
 };
 
 /**
  * This is an example of a badge used with a title.
  */
 const TitleExampleTemplate = ({ children }) => {
-    return (
-        <Flex align='center' columnGap={8}>
-            <Text type='h2' size='28'>
-                Huddly L1
-            </Text>
-            <Badge>{children}</Badge>
-        </Flex>
-    );
+  return (
+    <Flex align='center' columnGap={8}>
+      <Text type='h2' size='28'>
+        Huddly L1
+      </Text>
+      <Badge>{children}</Badge>
+    </Flex>
+  );
 };
 
 export const TitleExample = TitleExampleTemplate.bind({});
 TitleExample.args = {
-    children: 'New',
+  children: 'New',
 };

--- a/src/stories/Foundation/Badge/index.tsx
+++ b/src/stories/Foundation/Badge/index.tsx
@@ -2,23 +2,23 @@ import React from 'react';
 import styled from 'styled-components';
 
 const Wrapper = styled.span`
-    background-color: var(--color-lavender);
-    color: var(--color-white);
-    font-family: var(--font-family);
-    font-size: 14px;
-    padding: 2px 5px;
-    height: 100%;
+  background-color: var(--color-lavender);
+  color: var(--color-white);
+  font-family: var(--font-family);
+  font-size: 14px;
+  padding: 2px 5px;
+  height: 100%;
 `;
 
 export interface BadgeProps {
-    children: React.ReactChild;
+  children: React.ReactChild;
 }
 
 /**
  * Badge component
  */
 export const Badge = ({ children }: BadgeProps) => {
-    return <Wrapper>{children}</Wrapper>;
+  return <Wrapper>{children}</Wrapper>;
 };
 
 export default Badge;

--- a/src/stories/Foundation/Flex/Flex.stories.tsx
+++ b/src/stories/Foundation/Flex/Flex.stories.tsx
@@ -4,38 +4,38 @@ import React from 'react';
 export default { component: Flex };
 
 const placeholderStyles = {
-    display: 'grid',
-    width: '100px',
-    height: '100px',
-    color: 'var(--color-white)',
-    backgroundColor: 'var(--color-lavender)',
-    placeItems: 'center',
+  display: 'grid',
+  width: '100px',
+  height: '100px',
+  color: 'var(--color-white)',
+  backgroundColor: 'var(--color-lavender)',
+  placeItems: 'center',
 };
 
 export const DirectionRow = {
-    args: {
-        children: (
-            <>
-                <div style={placeholderStyles}>1</div>
-                <div style={placeholderStyles}>2</div>
-                <div style={placeholderStyles}>3</div>
-            </>
-        ),
-        columnGap: 16,
-        direction: 'row',
-    },
+  args: {
+    children: (
+      <>
+        <div style={placeholderStyles}>1</div>
+        <div style={placeholderStyles}>2</div>
+        <div style={placeholderStyles}>3</div>
+      </>
+    ),
+    columnGap: 16,
+    direction: 'row',
+  },
 };
 
 export const DirectionColumn = {
-    args: {
-        children: (
-            <>
-                <div style={placeholderStyles}>1</div>
-                <div style={placeholderStyles}>2</div>
-                <div style={placeholderStyles}>3</div>
-            </>
-        ),
-        rowGap: 16,
-        direction: 'column',
-    },
+  args: {
+    children: (
+      <>
+        <div style={placeholderStyles}>1</div>
+        <div style={placeholderStyles}>2</div>
+        <div style={placeholderStyles}>3</div>
+      </>
+    ),
+    rowGap: 16,
+    direction: 'column',
+  },
 };

--- a/src/stories/Foundation/Flex/index.tsx
+++ b/src/stories/Foundation/Flex/index.tsx
@@ -3,61 +3,61 @@ import styled from 'styled-components';
 import { Spacing8 } from '../../../shared/types';
 
 export interface FlexProps {
-    direction?: 'row' | 'row-reverse' | 'column' | 'column-revers';
-    wrap?: 'nowrap' | 'wrap' | 'wrap-reverse';
-    justify?:
-        | 'flex-start'
-        | 'flex-end'
-        | 'center'
-        | 'space-between'
-        | 'space-around'
-        | 'space-evenly';
-    align?:
-        | 'flex-start'
-        | 'flex-end'
-        | 'stretch'
-        | 'center'
-        | 'space-between'
-        | 'space-around';
-    rowGap?: Spacing8;
-    columnGap?: Spacing8;
-    children: JSX.Element | JSX.Element[];
+  direction?: 'row' | 'row-reverse' | 'column' | 'column-revers';
+  wrap?: 'nowrap' | 'wrap' | 'wrap-reverse';
+  justify?:
+    | 'flex-start'
+    | 'flex-end'
+    | 'center'
+    | 'space-between'
+    | 'space-around'
+    | 'space-evenly';
+  align?:
+    | 'flex-start'
+    | 'flex-end'
+    | 'stretch'
+    | 'center'
+    | 'space-between'
+    | 'space-around';
+  rowGap?: Spacing8;
+  columnGap?: Spacing8;
+  children: JSX.Element | JSX.Element[];
 }
 
 const Wrapper = styled.div<FlexProps>`
-    display: flex;
-    flex-direction: ${(p) => p.direction};
-    flex-wrap: ${(p) => p.wrap};
-    align-items: ${(p) => p.align};
-    justify-content: ${(p) => p.justify};
-    row-gap: ${(p) => `var(--spacing-${p.rowGap})`};
-    column-gap: ${(p) => `var(--spacing-${p.columnGap})`};
+  display: flex;
+  flex-direction: ${(p) => p.direction};
+  flex-wrap: ${(p) => p.wrap};
+  align-items: ${(p) => p.align};
+  justify-content: ${(p) => p.justify};
+  row-gap: ${(p) => `var(--spacing-${p.rowGap})`};
+  column-gap: ${(p) => `var(--spacing-${p.columnGap})`};
 `;
 
 /**
  * Flex component
  */
 export const Flex = ({
-    direction = 'row',
-    wrap = 'nowrap',
-    justify = 'flex-start',
-    align = 'center',
-    rowGap,
-    columnGap,
-    children,
+  direction = 'row',
+  wrap = 'nowrap',
+  justify = 'flex-start',
+  align = 'center',
+  rowGap,
+  columnGap,
+  children,
 }: FlexProps) => {
-    return (
-        <Wrapper
-            direction={direction}
-            wrap={wrap}
-            justify={justify}
-            align={align}
-            rowGap={rowGap}
-            columnGap={columnGap}
-        >
-            {children}
-        </Wrapper>
-    );
+  return (
+    <Wrapper
+      direction={direction}
+      wrap={wrap}
+      justify={justify}
+      align={align}
+      rowGap={rowGap}
+      columnGap={columnGap}
+    >
+      {children}
+    </Wrapper>
+  );
 };
 
 export default Flex;

--- a/src/stories/Foundation/Text/Text.stories.tsx
+++ b/src/stories/Foundation/Text/Text.stories.tsx
@@ -1,11 +1,11 @@
-import { Text } from ".";
+import { Text } from '.';
 
 export default { component: Text };
 
 export const MessinaSansRegular = {
-  args: { children: "Hello this is text" },
+  args: { children: 'Hello this is text' },
 };
 
 export const MessinaSansBold = {
-  args: { bold: true, children: "Hello this is text" },
+  args: { bold: true, children: 'Hello this is text' },
 };

--- a/src/stories/Foundation/Text/index.tsx
+++ b/src/stories/Foundation/Text/index.tsx
@@ -2,45 +2,45 @@ import React from 'react';
 import styled from 'styled-components';
 
 export const Wrapper = styled.p<TextProps>`
-    margin: 0;
-    line-height: 1.2em;
-    font-size: ${(p) => `var(--font-size-${p.size})`};
-    color: ${(p) => `var(--color-${p.color})`};
-    font-weight: ${(p) => (p.bold ? 'bold' : 'normal')};
+  margin: 0;
+  line-height: 1.2em;
+  font-size: ${(p) => `var(--font-size-${p.size})`};
+  color: ${(p) => `var(--color-${p.color})`};
+  font-weight: ${(p) => (p.bold ? 'bold' : 'normal')};
 `;
 export interface TextProps {
-    size?: '14' | '18' | '22' | '28' | '48' | '68' | '98';
-    color?:
-        | 'lavender'
-        | 'sunYellow'
-        | 'black'
-        | 'signalOrange'
-        | 'white'
-        | 'signalOrange';
-    type?: 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'span';
-    bold?: boolean;
-    children: React.ReactChild;
+  size?: '14' | '18' | '22' | '28' | '48' | '68' | '98';
+  color?:
+    | 'lavender'
+    | 'sunYellow'
+    | 'black'
+    | 'signalOrange'
+    | 'white'
+    | 'signalOrange';
+  type?: 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'span';
+  bold?: boolean;
+  children: React.ReactChild;
 }
 /**
  * Text component
  */
 export const Text = ({
-    size = '14',
-    color = 'black',
-    type = 'p',
-    bold,
-    children,
+  size = '14',
+  color = 'black',
+  type = 'p',
+  bold,
+  children,
 }: TextProps) => {
-    return (
-        <Wrapper
-            as={type as TextProps['type']}
-            bold={bold}
-            size={size}
-            color={color}
-        >
-            {children}
-        </Wrapper>
-    );
+  return (
+    <Wrapper
+      as={type as TextProps['type']}
+      bold={bold}
+      size={size}
+      color={color}
+    >
+      {children}
+    </Wrapper>
+  );
 };
 
 export default Text;


### PR DESCRIPTION
Added pretty-quick for formatting staged files in commit. (This is especially useful for Windows users with the git config autocrlf option set to true).

Change to use eslint instead of tslint (tslint is deprecated).

Tabwidth 4 -> 2
