### PR TITLE
Proposal(Forms/Select): Accept and return array instead of joined string for values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,9 @@ export { GlobalStyles } from './shared/styles/global';
 export { variables } from './shared/styles/variables';
 export { fonts } from './shared/styles/fonts';
 export { normalize } from './shared/styles/normalize';
-
 export * from './shared/types';
 export * from './shared/colors';
+
 /**
  * Forms
  */

--- a/src/stories/Forms/Select/Option.tsx
+++ b/src/stories/Forms/Select/Option.tsx
@@ -65,10 +65,11 @@ export const Option = React.forwardRef(
 
     return (
       <Wrapper
+        aria-selected={selected}
+        onClick={() => onChange?.(value)}
         ref={ref}
         role='option'
         tabIndex={isVisible ? 0 : -1}
-        onClick={() => onChange?.(value)}
       >
         {hasCheckbox && (
           <StyledCheckbox value={selected} onChange={() => onChange?.(value)} tabIndex={-1} />


### PR DESCRIPTION
### Before:

```typescript
const selectedValues = ['value1', 'value2', 'value3']

<Select 
  multiselect 
  value={selectedValues.join(',')} 
  onChange={(newValues) => setSelectedValues(newValues.split(','))} 
/>
```
###After:
```typescript
const selectedValues = ['value1', 'value2', 'value3']

<Select 
  multiselect 
  value={selectedValues} 
/>
````

This change allows for easier handling of multiselect values in the Select component and avoids the need to work with comma separated values, and escaping of values with commas.
It also allows for better integration with APIs that expect a comma separated string for multi-value selections. 

**Note that this change introduces a breaking API change and will require updates to any existing code that uses the multiple prop in the Select component.**