### PR TITLE
Feat(Forms): Input specific sizing css variables

### DIFF
--- a/src/shared/styles/variables.ts
+++ b/src/shared/styles/variables.ts
@@ -65,5 +65,12 @@ export const variables = css`
 
     /* Drop shadow */
     --drop-shadow-significant: 0px 3px 12px -3px rgba(0, 0, 0, 0.2);
+
+    /* Input sizing */
+    --input-toggle-size: var(--spacing-24);
+    --input-height: var(--spacing-48);
+    --input-padding: var(--spacing-16);
+    --input-radius: var(--border-radius);
+    --input-font-size: var(--font-size-16);
   }
 `;

--- a/src/shared/styles/variables.ts
+++ b/src/shared/styles/variables.ts
@@ -69,7 +69,6 @@ export const variables = css`
     /* Input sizing */
     --input-toggle-size: var(--spacing-24);
     --input-height: var(--spacing-48);
-    --input-padding: var(--spacing-16);
     --input-radius: var(--border-radius);
     --input-font-size: var(--font-size-16);
   }

--- a/src/stories/Forms/Checkbox/index.tsx
+++ b/src/stories/Forms/Checkbox/index.tsx
@@ -7,8 +7,6 @@ const FakeCheckbox = styled.label<{ hasError: boolean }>`
   display: flex;
   position: relative;
   align-items: center;
-  color: var(--color-grey15);
-  font-size: var(--font-size-14);
   cursor: pointer;
 
   // The fake custom checkbox
@@ -16,8 +14,8 @@ const FakeCheckbox = styled.label<{ hasError: boolean }>`
     display: block;
     flex-shrink: 0;
     box-sizing: border-box;
-    width: var(--spacing-24);
-    height: var(--spacing-24);
+    width: var(--input-toggle-size);
+    height: var(--input-toggle-size);
     border: ${({ hasError }) =>
       hasError ? 'var(--border-error)' : `${rem(2)} solid var(--color-grey55);`};
     border-radius: ${rem(2)};
@@ -42,6 +40,7 @@ const CheckboxInput = styled.input.attrs({ type: 'checkbox' })<GlobalInputProps>
     background-image: url("data:image/svg+xml,%3Csvg width='12' height='10' viewBox='0 0 12 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11.25 1.25L4.5 8L0.75 4.25' stroke='white' stroke-width='2'/%3E%3C/svg%3E%0A");
     background-repeat: no-repeat;
     background-position: center;
+    background-size: 50%;
   }
 
   &:hover:checked + ${FakeCheckbox}:before {
@@ -67,6 +66,8 @@ const CheckboxInput = styled.input.attrs({ type: 'checkbox' })<GlobalInputProps>
 
 const LabelText = styled.span`
   margin-left: var(--spacing-8);
+  color: var(--color-grey15);
+  font-size: var(--input-font-size);
 `;
 
 export interface CheckboxProps extends Omit<GlobalInputProps, 'value'> {

--- a/src/stories/Forms/Input/index.tsx
+++ b/src/stories/Forms/Input/index.tsx
@@ -12,7 +12,7 @@ const StyledInput = styled.input<{ hasError?: boolean }>`
   box-sizing: border-box;
   width: 100%;
   height: var(--input-height);
-  padding: var(--input-padding);
+  padding: var(--spacing-16);
   border: ${(p) => (p.hasError ? 'var(--border-error)' : 'var(--border-primary)')};
   border-radius: var(--input-radius);
   font-size: var(--input-font-size);

--- a/src/stories/Forms/Input/index.tsx
+++ b/src/stories/Forms/Input/index.tsx
@@ -4,17 +4,18 @@ import { GlobalInputProps } from '../../../shared/types';
 
 const Wrapper = styled.div<{ isHidden: boolean }>`
   display: ${(p) => (p.isHidden ? 'none' : 'block')};
+  flex: 1;
 `;
 
 const StyledInput = styled.input<{ hasError?: boolean }>`
   display: block;
   box-sizing: border-box;
   width: 100%;
-  height: var(--spacing-48);
-  padding: var(--spacing-16);
+  height: var(--input-height);
+  padding: var(--input-padding);
   border: ${(p) => (p.hasError ? 'var(--border-error)' : 'var(--border-primary)')};
-  border-radius: var(--border-radius);
-  font-size: var(--font-size-16);
+  border-radius: var(--input-radius);
+  font-size: var(--input-font-size);
   background: var(--color-grey96);
 
   :hover {

--- a/src/stories/Forms/InputWrapper/InputWrapper.stories.tsx
+++ b/src/stories/Forms/InputWrapper/InputWrapper.stories.tsx
@@ -2,13 +2,21 @@ import { InputWrapper } from '.';
 
 export default { component: InputWrapper };
 
-const Template = ({ severity, severityMessage, children, id, isRequired }) => {
+const Template = ({
+  severity,
+  severityMessage,
+  children,
+  id,
+  isRequired,
+  disableWidthConstraint,
+}) => {
   return (
     <InputWrapper
       severity={severity}
       severityMessage={severityMessage}
       id={id}
       isRequired={isRequired}
+      disableWidthConstraint={disableWidthConstraint}
     >
       {children}
     </InputWrapper>
@@ -27,6 +35,7 @@ Primary.args = {
       </p>
     </>
   ),
+  disableWidthConstraint: false,
 };
 
 export const HasHint = Template.bind({});

--- a/src/stories/Forms/InputWrapper/index.tsx
+++ b/src/stories/Forms/InputWrapper/index.tsx
@@ -8,6 +8,7 @@ interface WrapperProps {
   boxyErrorStyle: boolean;
   hasError: boolean;
   labelIsIndented?: boolean;
+  disableWidthConstraint?: boolean;
 }
 
 const Wrapper = styled.div<WrapperProps>`
@@ -15,7 +16,7 @@ const Wrapper = styled.div<WrapperProps>`
   flex-direction: column;
   justify-content: flex-end;
   width: 100%;
-  max-width: ${rem(400)};
+  max-width: ${(p) => (p.disableWidthConstraint ? 'none' : rem(400))};
   margin-bottom: var(--spacing-32);
 
   // Apply special styling when boxyErrorStyle is true and the input has an error.
@@ -60,6 +61,7 @@ export interface InputWrapperProps {
   children: JSX.Element | JSX.Element[];
   className?: string;
   isRequired?: boolean;
+  disableWidthConstraint?: boolean;
 }
 
 /**
@@ -67,7 +69,15 @@ export interface InputWrapperProps {
  */
 export const InputWrapper = React.forwardRef(
   (props: InputWrapperProps, ref: React.RefObject<HTMLDivElement>) => {
-    const { id, children, className, isRequired, severity, severityMessage } = props;
+    const {
+      id,
+      severity,
+      severityMessage,
+      children,
+      className,
+      isRequired,
+      disableWidthConstraint,
+    } = props;
     // Set aria id's. These are used for inputs and the helper texts.
     const ariaDescribedById = severity === 'info' ? `${id}-hint` : undefined;
     const ariaErrorMessageId = severity === ('error' || 'warning') ? `${id}-error` : undefined;
@@ -129,6 +139,7 @@ export const InputWrapper = React.forwardRef(
         {...HintWrapperProps}
         ref={ref}
         labelIsIndented={labelIsIndented}
+        disableWidthConstraint={disableWidthConstraint}
       >
         {childrenWithGlobalInputProps}
 

--- a/src/stories/Forms/MultiSelect/MultiSelect.tsx
+++ b/src/stories/Forms/MultiSelect/MultiSelect.tsx
@@ -292,7 +292,7 @@ export const MultiSelect = React.forwardRef(
           ref={ref}
           required={isRequired}
           type='hidden'
-          value={localValue.join(',')}
+          value={localValue?.join(',')}
           {...additionalInputProps}
         />
       </Styled.Wrapper>

--- a/src/stories/Forms/NativeSelect/index.tsx
+++ b/src/stories/Forms/NativeSelect/index.tsx
@@ -12,7 +12,7 @@ const Wrapper = styled.div<WrapperProps>`
     box-sizing: border-box;
     width: 100%;
     height: var(--input-height);
-    padding-inline: var(--input-padding);
+    padding-inline: var(--spacing-16);
     border: ${(p) => (p.hasError ? 'var(--border-error)' : 'var(--border-primary)')};
     border-radius: var(--input-radius);
     font-size: var(--input-font-size);

--- a/src/stories/Forms/NativeSelect/index.tsx
+++ b/src/stories/Forms/NativeSelect/index.tsx
@@ -11,11 +11,11 @@ const Wrapper = styled.div<WrapperProps>`
     display: block;
     box-sizing: border-box;
     width: 100%;
-    height: var(--spacing-48);
-    padding: 0 var(--spacing-16);
+    height: var(--input-height);
+    padding-inline: var(--input-padding);
     border: ${(p) => (p.hasError ? 'var(--border-error)' : 'var(--border-primary)')};
-    border-radius: var(--border-radius);
-    font-size: var(--font-size-16);
+    border-radius: var(--input-radius);
+    font-size: var(--input-font-size);
     font-family: var(--font-family-primary);
     cursor: pointer;
     // This is to get a custom arrow on the select element

--- a/src/stories/Forms/Radio/index.tsx
+++ b/src/stories/Forms/Radio/index.tsx
@@ -7,8 +7,6 @@ const FakeRadio = styled.label<{ hasError: boolean }>`
   display: flex;
   position: relative;
   align-items: center;
-  color: var(--color-grey15);
-  font-size: var(--font-size-14);
   cursor: pointer;
 
   // The fake custom checkbox
@@ -16,8 +14,8 @@ const FakeRadio = styled.label<{ hasError: boolean }>`
     display: block;
     flex-shrink: 0;
     box-sizing: border-box;
-    width: var(--spacing-24);
-    height: var(--spacing-24);
+    width: var(--input-toggle-size);
+    height: var(--input-toggle-size);
     border: ${({ hasError }) =>
       hasError ? 'var(--border-error)' : `${rem(2)} solid var(--color-grey55);`};
     border-radius: 50%;
@@ -42,6 +40,7 @@ const RadioInput = styled.input.attrs({ type: 'radio' })<GlobalInputProps>`
     background-image: url("data:image/svg+xml,%3Csvg width='12' height='12' viewBox='0 0 12 12' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='6' cy='6' r='6' fill='white'/%3E%3C/svg%3E%0A");
     background-repeat: no-repeat;
     background-position: center;
+    background-size: 50%;
   }
 
   &:hover:checked + ${FakeRadio}:before {
@@ -67,6 +66,8 @@ const RadioInput = styled.input.attrs({ type: 'radio' })<GlobalInputProps>`
 
 const LabelText = styled.span`
   margin-left: var(--spacing-8);
+  color: var(--color-grey15);
+  font-size: var(--input-font-size);
 `;
 
 export interface RadioProps extends Omit<GlobalInputProps, 'value'> {

--- a/src/stories/Forms/Select/Option.tsx
+++ b/src/stories/Forms/Select/Option.tsx
@@ -7,11 +7,12 @@ const Wrapper = styled.li`
   display: flex;
   position: relative;
   align-items: center;
-  padding: ${rem(12)} var(--spacing-16);
+  padding: ${rem(12)} var(--input-padding);
   outline: 0;
   column-gap: var(--spacing-8);
   cursor: pointer;
   transition: background-color 0.2s ease-in-out;
+  font-size: var(--input-font-size);
 
   &:not(:last-child) {
     border-bottom: ${rem(1)} solid var(--color-grey91);

--- a/src/stories/Forms/Select/Option.tsx
+++ b/src/stories/Forms/Select/Option.tsx
@@ -7,7 +7,7 @@ const Wrapper = styled.li`
   display: flex;
   position: relative;
   align-items: center;
-  padding: ${rem(12)} var(--input-padding);
+  padding: ${rem(12)} var(--spacing-16);
   outline: 0;
   column-gap: var(--spacing-8);
   cursor: pointer;

--- a/src/stories/Forms/Select/Select.stories.tsx
+++ b/src/stories/Forms/Select/Select.stories.tsx
@@ -11,12 +11,11 @@ export const Primary = {
   args: {
     id: 'select',
     isRequired: true,
-    multiselect: false,
     placeholder: '',
   },
 };
 
-const Template = ({ id, isRequired, multiselect, placeholder, severity, severityMessage }) => {
+const Template = ({ id, isRequired, placeholder, severity, severityMessage }) => {
   return (
     <InputWrapper
       severity={severity}

--- a/src/stories/Forms/Select/styled.ts
+++ b/src/stories/Forms/Select/styled.ts
@@ -23,15 +23,16 @@ export const SelectButton = styled.button<{
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: var(--spacing-48);
-  padding: var(--spacing-16) var(--spacing-8) var(--spacing-16) var(--spacing-16);
+  width: 100%;
+  height: var(--input-height);
+  padding: var(--input-padding);
   border: ${(p) => (p.hasError ? 'var(--border-error)' : 'var(--border-primary)')};
-  border-radius: ${rem(3)};
+  border-radius: var(--input-radius);
+  column-gap: var(--spacing-8);
   color: ${(p) => (p.hasLabel ? 'var(--color-grey15)' : 'var(--color-grey55)')};
+  font-size: var(--input-font-size);
   cursor: pointer;
   background-color: ${(p) => (p.isOpen ? 'var(--color-grey96)' : 'var(--color-grey99)')};
-  column-gap: var(--spacing-8);
-  width: 100%;
 
   &:hover {
     background-color: var(--color-grey96);
@@ -71,6 +72,7 @@ export const SelectedContent = styled.span<{ hasNestedContent: boolean }>`
 export const RotatingChevron = styled(ChevronDown)<{ rotate: boolean }>`
   transition: 0.15s ease-in-out;
   ${(p) => (p.rotate ? 'transform: rotate(180deg);' : 'transform: rotate(0deg);')}
+  margin-right: ${rem(-8)};
 
   path {
     fill: var(--color-grey35);

--- a/src/stories/Forms/Select/styled.ts
+++ b/src/stories/Forms/Select/styled.ts
@@ -25,7 +25,7 @@ export const SelectButton = styled.button<{
   align-items: center;
   width: 100%;
   height: var(--input-height);
-  padding: var(--input-padding);
+  padding: var(--spacing-16);
   border: ${(p) => (p.hasError ? 'var(--border-error)' : 'var(--border-primary)')};
   border-radius: var(--input-radius);
   column-gap: var(--spacing-8);
@@ -103,7 +103,7 @@ export const SelectList = styled.ul<{ height: number }>`
   height: ${(p) => rem(p.height)};
   margin: 0;
   padding: 0;
-  border-radius: ${rem(3)};
+  border-radius: var(--input-radius);
   overflow-y: auto;
   list-style: none;
   border: var(--border-active);

--- a/src/stories/Forms/TextArea/TextArea.stories.tsx
+++ b/src/stories/Forms/TextArea/TextArea.stories.tsx
@@ -10,10 +10,11 @@ export default {
 export const Primary = {
   args: {
     id: 'example',
+    height: 120,
   },
 };
 
-const Template = ({ severity, severityMessage, id, isRequired }) => {
+const Template = ({ severity, severityMessage, id, isRequired, height }) => {
   return (
     <InputWrapper
       severity={severity}
@@ -22,7 +23,7 @@ const Template = ({ severity, severityMessage, id, isRequired }) => {
       isRequired={isRequired}
     >
       <Label>Label</Label>
-      <TextArea />
+      <TextArea height={height} />
     </InputWrapper>
   );
 };

--- a/src/stories/Forms/TextArea/index.tsx
+++ b/src/stories/Forms/TextArea/index.tsx
@@ -14,7 +14,7 @@ const Wrapper = styled.div<WrapperProps>`
     box-sizing: border-box;
     width: 100%;
     height: ${(p) => rem(p.height)};
-    padding: var(--input-padding);
+    padding: var(--spacing-16);
     border: ${(p) => (p.hasError ? 'var(--border-error)' : 'var(--border-primary)')};
     border-radius: var(--input-radius);
     font-size: var(--input-font-size);

--- a/src/stories/Forms/TextArea/index.tsx
+++ b/src/stories/Forms/TextArea/index.tsx
@@ -5,6 +5,7 @@ import { GlobalInputProps } from '../../../shared/types';
 
 interface WrapperProps {
   hasError?: boolean;
+  height: number;
 }
 
 const Wrapper = styled.div<WrapperProps>`
@@ -12,25 +13,35 @@ const Wrapper = styled.div<WrapperProps>`
     display: block;
     box-sizing: border-box;
     width: 100%;
-    height: ${rem(120)};
-    padding: var(--spacing-16);
+    height: ${(p) => rem(p.height)};
+    padding: var(--input-padding);
     border: ${(p) => (p.hasError ? 'var(--border-error)' : 'var(--border-primary)')};
-    border-radius: var(--border-radius);
+    border-radius: var(--input-radius);
+    font-size: var(--input-font-size);
     font-family: var(--font-family-primary);
     resize: vertical;
   }
 `;
 
+export interface TextAreaProps extends GlobalInputProps {
+  /**
+   * Height of the textarea in pixels.
+   * @default 120
+   */
+  height?: number;
+}
+
 /**
  * TextArea component
  */
 export const TextArea = React.forwardRef(
-  (props: GlobalInputProps, ref: React.RefObject<HTMLTextAreaElement>) => {
+  (props: TextAreaProps, ref: React.RefObject<HTMLTextAreaElement>) => {
     const {
       ariaDescribedBy,
       ariaErrorMessage,
       className,
       hasError,
+      height = 120,
       id,
       isRequired,
       name,
@@ -39,7 +50,7 @@ export const TextArea = React.forwardRef(
     } = props;
 
     return (
-      <Wrapper className={className} hasError={hasError}>
+      <Wrapper className={className} hasError={hasError} height={height}>
         <textarea
           aria-labelledby={ariaDescribedBy}
           aria-errormessage={ariaErrorMessage}

--- a/src/stories/Forms/Toggle/index.tsx
+++ b/src/stories/Forms/Toggle/index.tsx
@@ -24,6 +24,7 @@ const StyledInput = styled.input<{ hasError?: boolean }>`
   background: var(--color-grey55);
   appearance: none;
   outline: none;
+  cursor: pointer;
 
   // the before element is adding the circle to the toggle button
   ::before {


### PR DESCRIPTION
When using input components in production in places such as our website, the components have a slightly different design language. Differences include things such as ~~padding~~, font-size and border-radius'. This PR introduces global css variables to adjust these styles.

_Edit: Padding was removed as it conflicted with inline padding rules for components such as Label, SeverityText etc.
The solution was to only enable it for padding-block. However, due to how inputs positions all content vertically centered by default, using height is sufficient, therefore making `--input-padding` unnecessary._

#### The following variables have been added:
```css
/* Input sizing */
--input-toggle-size: var(--spacing-24);
--input-height: var(--spacing-48);
--input-radius: var(--border-radius);
--input-font-size: var(--font-size-16);
```

#### The following components have been adjusted to use the new sizing variables:
- Checkbox
- Input
- MultiSelect
- NativeSelect
- Option
- PhoneInput
- Radio
- Select
- TextArea

It's worth noting that this PR shouldn't change existing styling.