### PR TITLE
Feat(Forms/TextArea): Inherit styles from input

### DIFF
--- a/src/stories/Forms/Input/index.tsx
+++ b/src/stories/Forms/Input/index.tsx
@@ -7,7 +7,7 @@ const Wrapper = styled.div<{ isHidden: boolean }>`
   flex: 1;
 `;
 
-const StyledInput = styled.input<{ hasError?: boolean }>`
+export const StyledInput = styled.input<{ hasError?: boolean }>`
   display: block;
   box-sizing: border-box;
   width: 100%;

--- a/src/stories/Forms/TextArea/index.tsx
+++ b/src/stories/Forms/TextArea/index.tsx
@@ -2,25 +2,16 @@ import React from 'react';
 import styled from 'styled-components';
 import rem from '../../../shared/pxToRem';
 import { GlobalInputProps } from '../../../shared/types';
+import { StyledInput } from '../Input';
 
-interface WrapperProps {
-  hasError?: boolean;
-  height: number;
-}
+const Wrapper = styled.div`
+  flex: 1;
+`;
 
-const Wrapper = styled.div<WrapperProps>`
-  textarea {
-    display: block;
-    box-sizing: border-box;
-    width: 100%;
-    height: ${(p) => rem(p.height)};
-    padding: var(--spacing-16);
-    border: ${(p) => (p.hasError ? 'var(--border-error)' : 'var(--border-primary)')};
-    border-radius: var(--input-radius);
-    font-size: var(--input-font-size);
-    font-family: var(--font-family-primary);
-    resize: vertical;
-  }
+const StyledTextArea = styled(StyledInput)<{ hasError?: boolean; height: number }>`
+  padding-block: var(--spacing-16);
+  height: ${(p) => rem(p.height)};
+  resize: vertical;
 `;
 
 export interface TextAreaProps extends GlobalInputProps {
@@ -50,11 +41,14 @@ export const TextArea = React.forwardRef(
     } = props;
 
     return (
-      <Wrapper className={className} hasError={hasError} height={height}>
-        <textarea
-          aria-labelledby={ariaDescribedBy}
+      <Wrapper className={className}>
+        <StyledTextArea
+          as='textarea'
           aria-errormessage={ariaErrorMessage}
           aria-invalid={hasError}
+          aria-labelledby={ariaDescribedBy}
+          hasError={hasError}
+          height={height}
           id={id}
           name={name || id}
           ref={ref}

--- a/src/stories/Forms/TextArea/index.tsx
+++ b/src/stories/Forms/TextArea/index.tsx
@@ -9,9 +9,9 @@ const Wrapper = styled.div`
 `;
 
 const StyledTextArea = styled(StyledInput)<{ hasError?: boolean; height: number }>`
-  padding-block: var(--spacing-16);
   height: ${(p) => rem(p.height)};
   resize: vertical;
+  padding-block: var(--spacing-16);
 `;
 
 export interface TextAreaProps extends GlobalInputProps {


### PR DESCRIPTION
I've noticed TextArea styles being forgotten when there are updates to the Input component. This PR solves that by just inheriting all the styles and overruling the TextArea specific styles.

Thinking of doing the same to Radios, and inheriting the styles from Checkbox.